### PR TITLE
Changement du serveur en cloud3 de la notif

### DIFF
--- a/crypto-mobile/app.json
+++ b/crypto-mobile/app.json
@@ -33,7 +33,7 @@
         "android.permission.RECORD_AUDIO",
         "NOTIFICATIONS"
       ],
-      "package": "com.anjely.cryptomobile"
+      "package": "com.kenny4220.notification"
     },
     "plugins": [
       "expo-font",

--- a/crypto-mobile/google-services.json
+++ b/crypto-mobile/google-services.json
@@ -1,21 +1,21 @@
 {
   "project_info": {
-    "project_number": "723996625713",
-    "project_id": "cloud2-8c401",
-    "storage_bucket": "cloud2-8c401.firebasestorage.app"
+    "project_number": "200828048915",
+    "project_id": "cloud3-b97fe",
+    "storage_bucket": "cloud3-b97fe.firebasestorage.app"
   },
   "client": [
     {
       "client_info": {
-        "mobilesdk_app_id": "1:723996625713:android:578666b91189c41376be10",
+        "mobilesdk_app_id": "1:200828048915:android:bfb6cee07ff1df75cc51e6",
         "android_client_info": {
-          "package_name": "com.anjely.cryptomobile"
+          "package_name": "com.kenny4220.notification"
         }
       },
       "oauth_client": [],
       "api_key": [
         {
-          "current_key": "AIzaSyBuEH8lp281Lxsm_K2Mq5tz0w-K9cNvC2c"
+          "current_key": "AIzaSyAzOBb32c9HVDt_NBdAPx_4Sk6qJJcZd1I"
         }
       ],
       "services": {


### PR DESCRIPTION
- cloud 2 devient cloud 3
- test du systeme de notif depot/retrait
- lien du apk actuel : https://expo.dev/accounts/anjely/projects/crypto-mobile/builds/1c89651d-48ae-44f0-a346-2f430659f5c8